### PR TITLE
Upgrade droplets to Ubuntu 22.04

### DIFF
--- a/src/config_manager.rb
+++ b/src/config_manager.rb
@@ -6,7 +6,7 @@ require 'json'
 class CONFIG_MANAGER
     
     CONFIG_FILE_NAME = "config/config.json"
-    FRESH_CONFIG_FILE = "{\n  \"Droplet_Name\": \"minecraft-bot-droplet\",\n  \"Droplet_Specs\": \"s-1vcpu-2gb\",\n  \"OS_Image\": \"ubuntu-20-04-x64\",\n  \"Default_Server\": \"minecraft-bot-default\",\n  \n  \"Information\": \"For the droplet specs/OS image, get the strings (slugs) from here:\",\n  \"Link_To_Slugs\": \"https://slugs.do-api.dev/\"\n}\n"
+    FRESH_CONFIG_FILE = "{\n  \"Droplet_Name\": \"minecraft-bot-droplet\",\n  \"Droplet_Specs\": \"s-1vcpu-2gb\",\n  \"OS_Image\": \"ubuntu-22-04-x64\",\n  \"Default_Server\": \"minecraft-bot-default\",\n  \n  \"Information\": \"For the droplet specs/OS image, get the strings (slugs) from here:\",\n  \"Link_To_Slugs\": \"https://slugs.do-api.dev/\"\n}\n"
     STARTUP_SCRIPT_FILE_NAME = "config/startup_script.txt"
     
     @config_data = nil


### PR DESCRIPTION
Ubuntu 22.04 LTS released this year, and it's worthwhile to go ahead and bump the project to create droplets using it. Minecraft is likely to start using newer Java versions in the future, and there are no guarantees that Ubuntu 20.04 will support them.